### PR TITLE
Ensure page IDs start with 'p' before loading settings

### DIFF
--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -83,6 +83,10 @@ class StateController extends Controller
                 $r->setData('{"error": "bad pageId"}');
                 return $r;
             }
+            if (!str_starts_with($pageId, 'p')) {
+                $r->setData('{"error": "bad pageId"}');
+                return $r;
+            }
 
             try {
                 $loaded = $this->utils->loadSettingsForUserAndPage($this->userId, $pageId);
@@ -218,6 +222,10 @@ class StateController extends Controller
                 }
 
             } else {
+                if (!str_starts_with($pageId, 'p')) {
+                    $r->setData('{"error": "bad pageId"}');
+                    return $r;
+                }
                 // delete the page if exists
                 try {
                     $pageExist = $this->utils->loadSettingsForUserAndPage($this->userId, $pageId);
@@ -268,6 +276,10 @@ class StateController extends Controller
             }
             if (empty($pageId)) {
                 $pageId = 'p0';
+            }
+            if (!str_starts_with($pageId, 'p')) {
+                $r->setData('{"error": "bad pageId"}');
+                return $r;
             }
 
             try {


### PR DESCRIPTION
## Summary
- Validate that incoming page IDs begin with 'p' before loading settings
- Return HTTP 400 for invalid page IDs

## Testing
- `make test-php` *(fails: phpunit: No such file or directory)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_b_6897285bdeb8832194ea0a889f5b1a14